### PR TITLE
Make buildAllRPIExamples.sh work from any directory

### DIFF
--- a/scripts/linux/buildAllRPIExamples.sh
+++ b/scripts/linux/buildAllRPIExamples.sh
@@ -1,4 +1,5 @@
-cd ../../examples
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd ${DIR}/../../examples
 for category in $(ls -1d *)
 do
 	if [ $category != "addons" ] && [ $category != "ios" ] && [ $category != "android" ]; then
@@ -9,9 +10,8 @@ do
 		do
 			echo ">>$j"
 			cd $j
-			cp ../../../scripts/linux/template/linuxarmv6l/Makefile .
-			make clean
-			make
+			make -f ../../../scripts/templates/linuxarmv6l/Makefile clean
+			make -f ../../../scripts/templates/linuxarmv6l/Makefile
 			ret=$?
 			if [ $ret -ne 0 ];
 			then


### PR DESCRIPTION
This makes it so you can just `cd /home/pi/openFrameworks && ./scripts/linux/buildAllRPIExamples.sh`

In addition, instead of copying the Makefiles everywhere, it just points make to the correct one. I can see how that might not be as helpful, so I can split it into two pull requests if you want.